### PR TITLE
Add requirement to README for Python 3.8.x to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ## Installation
 
-Houdini can be run as a normal Python program under any operating system.\n
+Houdini can be run as a normal Python program under any operating system.
 
 ***NOTE**: Houdini requires Python 3.8.x to be installed*
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@
 
 ## Installation
 
-Houdini can be run as a normal Python program under any operating system.
+Houdini can be run as a normal Python program under any operating system.\n
+
+***NOTE**: Houdini requires Python 3.8.x to be installed*
 
 ```shell
 $ git clone https://github.com/solero/houdini


### PR DESCRIPTION
When running the installer through pip and python, some Linux distros will default to Python 3.6.x as the most up to date Python version in their respective package managers. This should be mentioned so people know they should manually install Python 3.8.x