### PR TITLE
Backwards compatibility with Python 3.6 and upper.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,5 +1,4 @@
 import argparse
-import asyncio
 import logging
 
 from houdini.constants import ClientType, ConflictResolution, Language
@@ -137,7 +136,4 @@ if __name__ == '__main__':
     args.default_client = dict(legacy=ClientType.Legacy, vanilla=ClientType.Vanilla).get(args.default_client)
 
     factory_instance = Houdini(args)
-    try:
-        asyncio.run(factory_instance.start())
-    except KeyboardInterrupt:
-        logger.info('Shutting down...')
+    factory_instance.run()

--- a/houdini/data/igloo.py
+++ b/houdini/data/igloo.py
@@ -1,5 +1,4 @@
-from functools import cached_property
-
+from houdini.utils import cached_property
 from houdini.data import AbstractDataCollection, db
 
 

--- a/houdini/data/item.py
+++ b/houdini/data/item.py
@@ -1,5 +1,4 @@
-from functools import cached_property
-
+from houdini.utils import cached_property
 from houdini.data import AbstractDataCollection, db
 
 

--- a/houdini/data/penguin.py
+++ b/houdini/data/penguin.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from functools import cached_property
 
+from houdini.utils import cached_property
 from houdini.data import db
 
 

--- a/houdini/handlers/games/dance.py
+++ b/houdini/handlers/games/dance.py
@@ -148,7 +148,7 @@ async def songs_load(server):
     server.logger.info(f'Loaded {len(server.dance_songs)} dance tracks')
 
     server.dance_floor = DanceFloor(server)
-    asyncio.create_task(server.dance_floor.start())
+    server.loop.create_task(server.dance_floor.start())
 
 
 @handlers.handler(XTPacket('gz', ext='z'))

--- a/houdini/handlers/games/match.py
+++ b/houdini/handlers/games/match.py
@@ -119,9 +119,9 @@ async def match_load(server):
     server.water_match_making = MatchMaking(server, card_color_tick, card_water_matched,
                                             match_by='water_ninja_rank', max_players=4)
 
-    asyncio.create_task(server.match_making.start())
-    asyncio.create_task(server.fire_match_making.start())
-    asyncio.create_task(server.water_match_making.start())
+    server.loop.create_task(server.match_making.start())
+    server.loop.create_task(server.fire_match_making.start())
+    server.loop.create_task(server.water_match_making.start())
 
 
 @handlers.handler(XTPacket('jmm', ext='z'))

--- a/houdini/handlers/play/music.py
+++ b/houdini/handlers/play/music.py
@@ -55,7 +55,7 @@ class SoundStudio:
     async def start_broadcasting(self):
         if not self.broadcasting:
             self.broadcasting = True
-            asyncio.create_task(self.broadcast_tracks())
+            self.server.loop.create_task(self.broadcast_tracks())
 
     async def stop_broadcasting(self):
         if self.broadcasting:

--- a/houdini/handlers/play/pet.py
+++ b/houdini/handlers/play/pet.py
@@ -231,7 +231,7 @@ async def puffles_load(server):
     server.puffle_furniture_treasure = await PuffleTreasureFurniture.query.gino.all()
     server.puffle_clothing_treasure = await PuffleTreasureItem.query.gino.all()
 
-    server.puffle_killer = asyncio.create_task(decrease_stats(server))
+    server.puffle_killer = server.loop.create_task(decrease_stats(server))
 
 
 @handlers.handler(XMLPacket('login'), priority=Priority.Low)

--- a/houdini/handlers/play/player.py
+++ b/houdini/handlers/play/player.py
@@ -70,8 +70,8 @@ async def server_egg_timer(server):
 
 @handlers.boot
 async def heartbeat_service_start(server):
-    server.heartbeat = asyncio.create_task(server_heartbeat(server))
-    server.egg_timer = asyncio.create_task(server_egg_timer(server))
+    server.heartbeat = server.loop.create_task(server_heartbeat(server))
+    server.egg_timer = server.loop.create_task(server_egg_timer(server))
 
 
 MemberWarningDaysToExpiry = 14

--- a/houdini/spheniscidae.py
+++ b/houdini/spheniscidae.py
@@ -79,7 +79,7 @@ class Spheniscidae:
         await self.send_line(xml_data.decode('utf-8'))
 
     async def send_line(self, data):
-        if not self.__writer.is_closing():
+        if not self.is_writer_closing():
             self.logger.debug(f'Outgoing data: {data}')
             self.__writer.write(data.encode('utf-8') + Spheniscidae.Delimiter)
 
@@ -100,7 +100,7 @@ class Spheniscidae:
             packet_data = parsed_data[4:]
 
             for listener in xt_listeners:
-                if not self.__writer.is_closing() and listener.client_type is None \
+                if not self.is_writer_closing() and listener.client_type is None \
                         or listener.client_type == self.client_type:
                     await listener(self, packet_data)
             self.received_packets.add(packet)
@@ -127,7 +127,7 @@ class Spheniscidae:
                     xml_listeners = self.server.xml_listeners[packet]
 
                     for listener in xml_listeners:
-                        if not self.__writer.is_closing() and listener.client_type is None \
+                        if not self.is_writer_closing() and listener.client_type is None \
                                 or listener.client_type == self.client_type:
                             await listener(self, body_tag)
 
@@ -166,7 +166,7 @@ class Spheniscidae:
 
     async def run(self):
         await self._client_connected()
-        while not self.__writer.is_closing():
+        while not self.is_writer_closing():
             try:
                 data = await self.__reader.readuntil(
                     separator=Spheniscidae.Delimiter)
@@ -190,3 +190,7 @@ class Spheniscidae:
 
     def __repr__(self):
         return f'<Spheniscidae {self.peer_name}>'
+
+    def is_writer_closing(self):
+        transport = self.__writer._transport
+        return transport and transport.is_closing()

--- a/houdini/utils.py
+++ b/houdini/utils.py
@@ -1,0 +1,13 @@
+class cached_property:
+    def __init__(self, function):
+        self.function = function
+        self.__doc__ = getattr(function, '__doc__')
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        value = self.function(instance)
+        setattr(instance, self.function.__name__, value)
+
+        return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ defusedxml
 bcrypt
 uvloop; sys_platform != 'win32'
 pytz
+dataclasses; python_version < '3.7'


### PR DESCRIPTION
Basically substitutes APIs unavailable in lower versions.

I have tested these changes with Python 3.6.8, should any problems arise with other versions please let me know.