### PR TITLE
Update houdini.sql

### DIFF
--- a/houdini.sql
+++ b/houdini.sql
@@ -11643,8 +11643,8 @@ INSERT INTO penguin (id, username, nickname, approval_en, password, email, color
  (27, 'cece', 'CeCe', TRUE, '$2b$12$CCYijGFRZyymIJWWNpkmP.pysAEN5E1mRwPtrjIDmTR3LnhKdJeBK', '', 7, NULL),
  (28, 'merry walrus', 'Merry Walrus', TRUE, '$2b$12$CCYijGFRZyymIJWWNpkmP.pysAEN5E1mRwPtrjIDmTR3LnhKdJeBK', '', 1, NULL);
  
-INSERT INTO penguin (username, nickname, approval_en, active, password, email, color) VALUES
-  ('basil', 'Basil', TRUE, TRUE, '$2b$12$CCYijGFRZyymIJWWNpkmP.pysAEN5E1mRwPtrjIDmTR3LnhKdJeBK', 'basil@solero.me', 1);
+INSERT INTO penguin (username, nickname, approval_en, active, password, email, color, moderator) VALUES
+  ('basil', 'Basil', TRUE, TRUE, '$2b$12$CCYijGFRZyymIJWWNpkmP.pysAEN5E1mRwPtrjIDmTR3LnhKdJeBK', 'basil@solero.me', 1, TRUE);
   
 INSERT INTO penguin_item (penguin_id, item_id) VALUES
   (101, 1);


### PR DESCRIPTION
Change the houdini.sql so that, by default, the basil user is a moderator, so manager can be easily used without modifying the postgreSQL database.