### PR TITLE
Fix banned accounts not being removed

### DIFF
--- a/houdini/handlers/play/moderation.py
+++ b/houdini/handlers/play/moderation.py
@@ -111,7 +111,8 @@ async def cheat_ban(p, penguin_id, hours=24, comment=''):
 
         if penguin_id in p.server.penguins_by_id:
             await player.send_error_and_disconnect(611, comment)
-
+            await player.close()
+            
 
 async def moderator_kick(p, penguin_id):
     if penguin_id in p.server.penguins_by_id:
@@ -148,3 +149,5 @@ async def moderator_ban(p, penguin_id, hours=24, comment='', message=''):
                 await player.send_xt('ban', 612, 2, hours, comment)
             else:
                 await player.send_error_and_disconnect(610, comment)
+                
+            await player.close()


### PR DESCRIPTION
When a player gets banned, by a command, discord bot or the button in game, after clicking the 'ok' button, they can just... keep walking around (at least on the vanilla media server).

This fixes this by ensuring the client is disconnected.