### PR TITLE
Fix find-four exploit

### DIFF
--- a/houdini/handlers/games/four.py
+++ b/houdini/handlers/games/four.py
@@ -13,7 +13,7 @@ class ConnectFourLogic(ITable):
 
     def is_valid_move(self, col, row):
         if 0 <= row <= 5 and 0 <= col <= 6:
-            if row == 5 or (self.board[col][row] == 0 and self.board[col][row + 1]):
+            if (row == 5 or self.board[col][row + 1]) and self.board[col][row] == 0:
                 return True
         return False
 


### PR DESCRIPTION
Prevent users from being able to take already occupied slots on row 5.

The prior version of `is_valid_move` would skip other checks if the chip was placed in the fifth row.

This PR alters the `if`-statement to check if the slot is already occupied regardless of the row.