### PR TITLE
Support multi-module plugins

### DIFF
--- a/houdini/plugins/__init__.py
+++ b/houdini/plugins/__init__.py
@@ -58,7 +58,10 @@ class PluginManager(_AbstractManager):
             await self.load(plugin_package)
 
     async def load(self, module):
-        plugin_class, plugin_type = inspect.getmembers(module, is_plugin).pop()
+        try:
+            plugin_class, plugin_type = inspect.getmembers(module, is_plugin).pop()
+        except IndexError:
+            return
         plugin_index = plugin_class.lower()
 
         if self.server.config.plugins != '*' and \


### PR DESCRIPTION
## Context

I'm developing a bot plugin for Houdini [here](https://github.com/brosquinha/houdini-bot-plugin). Since I'm planning on adding a fairly amount of features, its source code started to grow a little too much for a single file, which lead me to slip it into multiple files to better organize it. However, Houdini expects all modules under `houdini/plugins` to contain a plugin subclass, so it currently does not support such multi-module plugins.

## Proposed solution

Ignore all non-plugin modules inside `houdini/plugins`.