### PR TITLE
Fix coin duplication glitch on as2

### DIFF
--- a/houdini/handlers/games/__init__.py
+++ b/houdini/handlers/games/__init__.py
@@ -31,6 +31,8 @@ async def determine_coins_overdose(p, coins):
 
     if coins > max_game_coins:
         return True
+
+    await p.server.redis.delete(overdose_key)
     return False
 
 


### PR DESCRIPTION
A bug discovered by @Boo6447 lets you duplicate coins, while bypassing the coin overdose checks:

https://github.com/solero/houdini/assets/84310095/0aa5d131-f68d-48cd-ab37-1a02d7095d7f

Houdini will not reset the overdose key until you leave the game, which explains why you don't get banned. My suggestion is to delete the overdose key after the coin overdose check, so that the following game over packets result in a ban.

https://github.com/solero/houdini/assets/84310095/309ac0bd-c051-40d4-b710-8a435143f5f1

Please let me know if there could be any issues with this approach.