### PR TITLE
Update Card-Jitsu belt progression system to be accurate to the original Club Penguin

### DIFF
--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -533,6 +533,8 @@ async def handle_send_sensei_pick(p, action: str, card_id: int):
                 can_rank_up = await ninja_rank_up(p)
                 if can_rank_up:
                     await p.send_xt('cza', p.ninja_rank)
+            else:
+                await ninja_progress(p, False)
         else:
             for seat_id, ninja in enumerate(p.waddle.ninjas):
                 if not p.waddle.has_cards_to_play(seat_id):

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -238,7 +238,7 @@ async def ninja_rank_up(p, ranks=1):
             await p.add_inbox(p.server.postcards[CardJitsuLogic.PostcardAwards[rank]])
         if rank in CardJitsuLogic.StampAwards:
             await p.add_stamp(p.server.stamps[CardJitsuLogic.StampAwards[rank]])
-    await p.update(ninja_rank=p.ninja_rank + ranks, ninja_progress=0).apply()
+    await p.update(ninja_rank=p.ninja_rank + ranks).apply()
     return True
 
 def get_exp_difference_to_next_rank(cur_rank: int) -> int:

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -246,10 +246,6 @@ def get_treshold_for_rank(rank: int) -> int:
     # using arithmetic progression sum because the exp structure allows 
     return (rank + 1) * rank // 2 * 5
 
-# rank doesn't need to be known, but requiring it since it is always known and is simpler/faster to compute
-def get_percentage_to_next_belt(xp: int, rank: int) -> int:
-    return int(((xp - get_treshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
-
 async def ninja_progress(p, won=False):
     # black belts don't need exp, otherwise it could overflow
     if p.ninja_rank >= 9:

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -242,7 +242,7 @@ async def ninja_rank_up(p, ranks=1):
 def get_exp_difference_to_next_rank(cur_rank: int) -> int:
     return (cur_rank + 1) * 5
 
-def get_treshold_for_rank(rank: int) -> int:
+def get_threshold_for_rank(rank: int) -> int:
     # using arithmetic progression sum because the exp structure allows 
     return (rank + 1) * rank // 2 * 5
 
@@ -251,10 +251,10 @@ async def ninja_progress(p, won=False):
     if p.ninja_rank >= 9:
         return
     gained_exp = 5 if won else 1
-    next_rank_threshold = get_treshold_for_rank(p.ninja_rank + 1)
+    next_rank_threshold = get_threshold_for_rank(p.ninja_rank + 1)
 
     # this clamping is for compatibility with older versions
-    previous_progress = max(min(p.ninja_progress, next_rank_threshold), get_treshold_for_rank(p.ninja_rank))
+    previous_progress = max(min(p.ninja_progress, next_rank_threshold), get_threshold_for_rank(p.ninja_rank))
     new_progress = previous_progress + gained_exp
     await p.update(ninja_progress=new_progress).apply()
     if new_progress >= next_rank_threshold:

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -251,9 +251,13 @@ async def ninja_progress(p, won=False):
     if p.ninja_rank >= 9:
         return
     gained_exp = 5 if won else 1
-    new_progress = p.ninja_progress + gained_exp
+    next_rank_threshold = get_treshold_for_rank(p.ninja_rank + 1)
+
+    # this clamping is for compatibility with older versions
+    previous_progress = max(min(p.ninja_progress, next_rank_threshold), get_treshold_for_rank(p.ninja_rank))
+    new_progress = previous_progress + gained_exp
     await p.update(ninja_progress=new_progress).apply()
-    if new_progress >= get_treshold_for_rank(p.ninja_rank + 1):
+    if new_progress >= next_rank_threshold:
         await ninja_rank_up(p)
         await p.send_xt('cza', p.ninja_rank)
 

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -251,10 +251,15 @@ async def ninja_progress(p, won=False):
     if p.ninja_rank >= 9:
         return
     gained_exp = 5 if won else 1
-    next_rank_threshold = get_threshold_for_rank(p.ninja_rank + 1)
 
-    # this clamping is for compatibility with older versions
-    previous_progress = max(min(p.ninja_progress, next_rank_threshold), get_threshold_for_rank(p.ninja_rank))
+    previous_progress = p.ninja_progress
+    cur_rank_threshold = get_threshold_for_rank(p.ninja_rank)
+    next_rank_threshold = get_threshold_for_rank(p.ninja_rank + 1)
+    # this is for correcting old versions, where the exp might not be in the proper threshold.
+    if previous_progress < cur_rank_threshold or previous_progress > next_rank_threshold:
+        # in this case, ninja_progress is the percentage to next belt
+        previous_progress = int(cur_rank_threshold + previous_progress * get_exp_difference_to_next_rank(p.ninja_rank) / 100)
+
     new_progress = previous_progress + gained_exp
     await p.update(ninja_progress=new_progress).apply()
     if new_progress >= next_rank_threshold:

--- a/houdini/handlers/games/ninja/card.py
+++ b/houdini/handlers/games/ninja/card.py
@@ -47,8 +47,6 @@ class CardJitsuLogic(IWaddle):
     StampAwards = {0: 230, 4: 232, 8: 234, 9: 236}
     StampGroupId = 38
 
-    RankSpeed = 1
-
     def __init__(self, waddle):
         super().__init__(waddle)
 
@@ -188,7 +186,7 @@ class CardJitsuLogic(IWaddle):
 
 
 class CardJitsuMatLogic(CardJitsuLogic):
-    RankSpeed = 0.5
+    pass
 
 
 class SenseiLogic(CardJitsuLogic):

--- a/houdini/handlers/play/ninja.py
+++ b/houdini/handlers/play/ninja.py
@@ -1,7 +1,11 @@
 from houdini import handlers
 from houdini.handlers import XTPacket
 from houdini.data.penguin import Penguin
-from houdini.handlers.games.ninja.card import get_percentage_to_next_belt
+from houdini.handlers.games.ninja.card import get_treshold_for_rank, get_exp_difference_to_next_rank
+
+# rank doesn't need to be known, but requiring it since it is always known and is simpler/faster to compute
+def get_percentage_to_next_belt(xp: int, rank: int) -> int:
+    return int(((xp - get_treshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
 
 @handlers.handler(XTPacket('ni', 'gnr'))
 @handlers.cooldown(2)

--- a/houdini/handlers/play/ninja.py
+++ b/houdini/handlers/play/ninja.py
@@ -1,7 +1,7 @@
 from houdini import handlers
 from houdini.handlers import XTPacket
 from houdini.data.penguin import Penguin
-
+from houdini.handlers.games.ninja.card import get_percentage_to_next_belt
 
 @handlers.handler(XTPacket('ni', 'gnr'))
 @handlers.cooldown(2)
@@ -13,7 +13,7 @@ async def handle_get_ninja_ranks(p, penguin_id: int):
 
 @handlers.handler(XTPacket('ni', 'gnl'))
 async def handle_get_ninja_level(p):
-    await p.send_xt('gnl', p.ninja_rank, p.ninja_progress, 10)
+    await p.send_xt('gnl', p.ninja_rank, get_percentage_to_next_belt(p.ninja_progress, p.ninja_rank), 10)
 
 
 @handlers.handler(XTPacket('ni', 'gfl'))

--- a/houdini/handlers/play/ninja.py
+++ b/houdini/handlers/play/ninja.py
@@ -1,11 +1,11 @@
 from houdini import handlers
 from houdini.handlers import XTPacket
 from houdini.data.penguin import Penguin
-from houdini.handlers.games.ninja.card import get_treshold_for_rank, get_exp_difference_to_next_rank
+from houdini.handlers.games.ninja.card import get_threshold_for_rank, get_exp_difference_to_next_rank
 
 # rank doesn't need to be known, but requiring it since it is always known and is simpler/faster to compute
 def get_percentage_to_next_belt(xp: int, rank: int) -> int:
-    return int(((xp - get_treshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
+    return int(((xp - get_threshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
 
 @handlers.handler(XTPacket('ni', 'gnr'))
 @handlers.cooldown(2)


### PR DESCRIPTION
Currently, the system is inacurate. If you don't believe me or want to learn about what the system was, I have written out a detailed document where I lay down all the evidence and explain what the system was, and you [may read it here](https://docs.google.com/document/d/1F0ijtA-6F8IKr62oP7cpm3d1DInM2J_hUxDYHd2l9T8/edit?usp=sharing).

Here is what is changed:

1. Losing is 1/5 of the winning EXP, not 1/2
2. Mats give the same amount of EXP as random matchups
3. Sensei gives EXP even if you lose before having a black belt
4. EXP is not reset between levels, some is leftover and converted to a new scale when displayed on the percentages
5. The number of wins per belt is now correct, it was slightly inacurate before

# Compatibility

It is not possible to make all these changes while having a fully backward compatible database (or if it is, it would be unecessarily complicated). But, this still uses the same database schema and old databases could be fixed easily with a script that converts the numbers. If the numbers are the same from the previous system, the game will still work fine but players will report weird issues if they were not black belt already, which would eventually fix itself if they played enough games.