### PR TITLE
Change card-jitsu fire progression system to be like original

### DIFF
--- a/houdini/handlers/games/ninja/fire.py
+++ b/houdini/handlers/games/ninja/fire.py
@@ -526,8 +526,7 @@ async def fire_ninja_rank_up(p, ranks=1):
         if rank in CardJitsuFireLogic.StampAwards:
             await p.add_stamp(p.server.stamps[CardJitsuFireLogic.StampAwards[rank]])
     await p.update(
-        fire_ninja_rank=p.fire_ninja_rank + ranks,
-        fire_ninja_progress=p.fire_ninja_progress % 100
+        fire_ninja_rank=p.fire_ninja_rank + ranks
     ).apply()
     return True
 

--- a/houdini/handlers/play/ninja.py
+++ b/houdini/handlers/play/ninja.py
@@ -2,10 +2,17 @@ from houdini import handlers
 from houdini.handlers import XTPacket
 from houdini.data.penguin import Penguin
 from houdini.handlers.games.ninja.card import get_threshold_for_rank, get_exp_difference_to_next_rank
+from houdini.handlers.games.ninja.fire import get_fire_rank_threshold
 
 # rank doesn't need to be known, but requiring it since it is always known and is simpler/faster to compute
 def get_percentage_to_next_belt(xp: int, rank: int) -> int:
     return int(((xp - get_threshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
+
+def get_percentage_to_next_fire_item(xp: int, rank: int) -> int:
+    if rank >= 4:
+        return 0
+    cur_threshold = get_fire_rank_threshold(rank)
+    return int((xp - cur_threshold) / (get_fire_rank_threshold(rank + 1) - cur_threshold) * 100)
 
 @handlers.handler(XTPacket('ni', 'gnr'))
 @handlers.cooldown(2)
@@ -22,7 +29,7 @@ async def handle_get_ninja_level(p):
 
 @handlers.handler(XTPacket('ni', 'gfl'))
 async def handle_get_fire_level(p):
-    await p.send_xt('gfl', p.fire_ninja_rank, p.fire_ninja_progress, 5)
+    await p.send_xt('gfl', p.fire_ninja_rank, get_percentage_to_next_fire_item(p.fire_ninja_progress, p.fire_ninja_rank), 5)
 
 
 @handlers.handler(XTPacket('ni', 'gwl'))


### PR DESCRIPTION
Similar as the Card-Jitsu one, changed how the percentages progress. I have a in-detail document for fire as well [here](https://docs.google.com/document/d/1n5-oSv_Yy0sqMtLHo6724X5XPuBz2aV8eFBYk16wn2Y/edit?usp=sharing), but overall:

1. Once again, mats give the same amount of EXP as random matches
2. Progress is restructured into an EXP system
3. The EXP from a match is determined by the number of people and how well you did
4. Added the same retro compatibility as the card-jitsu change, so likewise this one also will work with older databases