### PR TITLE
Change card-jitsu fire progression system to be like original

### DIFF
--- a/houdini/handlers/games/ninja/fire.py
+++ b/houdini/handlers/games/ninja/fire.py
@@ -39,8 +39,6 @@ class CardJitsuFireLogic(IWaddle):
     ItemAwards = [6025, 4120, 2013, 1086, 3032]
     StampAwards = {2: 256, 4: 262}
 
-    RankSpeed = 1
-
     def __init__(self, waddle):
         super().__init__(waddle)
 
@@ -329,7 +327,7 @@ class CardJitsuFireLogic(IWaddle):
                         player_finish_position = self.podium[n.seat_id]
 
                         await end_game_stamps(n, player_finish_position)
-                        await fire_ninja_progress(n.penguin, self.podium[n.seat_id])
+                        await fire_ninja_progress(n.penguin, self.podium[n.seat_id], len(self.podium))
 
                         finish_positions = ','.join(str(max(position, 1)) for position in self.podium)
                         await n.penguin.send_xt('zm', 'zo', finish_positions)
@@ -397,8 +395,7 @@ class CardJitsuFireLogic(IWaddle):
 
 
 class FireMatLogic(CardJitsuFireLogic):
-
-    RankSpeed = 0.5
+    pass
 
 
 class FireSenseiLogic(CardJitsuFireLogic):
@@ -481,7 +478,7 @@ class FireSenseiLogic(CardJitsuFireLogic):
             player_finish_position = self.podium[ninja.seat_id]
             if player_finish_position > 0:
                 await end_game_stamps(ninja, player_finish_position)
-                await fire_ninja_progress(ninja.penguin, player_finish_position)
+                await fire_ninja_progress(ninja.penguin, player_finish_position, len(self.podium))
 
                 await ninja.penguin.send_xt('zm', 'zo', finish_positions)
                 await self.remove_penguin(ninja.penguin, quit_early=False)
@@ -529,20 +526,39 @@ async def fire_ninja_rank_up(p, ranks=1):
         if rank in CardJitsuFireLogic.StampAwards:
             await p.add_stamp(p.server.stamps[CardJitsuFireLogic.StampAwards[rank]])
     await p.update(
-        fire_ninja_rank=p.fire_ninja_rank + ranks,
-        fire_ninja_progress=p.fire_ninja_progress % 100
+        fire_ninja_rank=p.fire_ninja_rank + ranks
     ).apply()
     return True
 
+# exp required to reach this rank
+def get_fire_rank_threshold(rank):
+    try:
+        return [0, 25, 75, 175, 325][rank]
+    except:
+        return
 
-async def fire_ninja_progress(p, finish_position=1):
-    if p.fire_ninja_rank < 4:
-        speed = type(p.waddle).RankSpeed
-        points = math.floor((25 / (p.fire_ninja_rank+1) / finish_position) * speed)
-        await p.update(fire_ninja_progress=p.fire_ninja_progress+points).apply()
-    elif type(p.waddle) == FireSenseiLogic and p.fire_ninja_rank == 4 and finish_position == 1:
-        await p.update(fire_ninja_progress=100).apply()
-    if p.fire_ninja_progress >= 100:
+async def fire_ninja_progress(p, finish_position, players_number):
+    has_suit = p.fire_ninja_rank >= 4
+    is_sensei = type(p.waddle) == FireSenseiLogic
+    beat_sensei = is_sensei and p.fire_ninja_rank == 4 and finish_position == 1
+    
+    cur_rank_threshold = get_fire_rank_threshold(p.fire_ninja_rank)
+    next_rank_threshold = get_fire_rank_threshold(p.fire_ninja_rank + 1)
+    # scenarios you are allowed to earn XP
+    if not has_suit and not is_sensei:
+        previous_progress = p.fire_ninja_progress
+        # for older versions where the progress was the percentage
+        if previous_progress < cur_rank_threshold or previous_progress > next_rank_threshold:
+            previous_progress = int(cur_rank_threshold + previous_progress / 100 * (next_rank_threshold - cur_rank_threshold))
+        points = [
+            [9, 3],
+            [12, 6, 3],
+            [15, 9, 6, 3],
+        ][players_number - 2][finish_position - 1]
+        await p.update(fire_ninja_progress=previous_progress+points).apply()
+    
+    got_new_item = not has_suit and p.fire_ninja_progress >= next_rank_threshold
+    if beat_sensei or got_new_item:
         await fire_ninja_rank_up(p)
         await p.send_xt('zm', 'nr', 0, p.fire_ninja_rank)
 

--- a/houdini/handlers/play/ninja.py
+++ b/houdini/handlers/play/ninja.py
@@ -2,10 +2,17 @@ from houdini import handlers
 from houdini.handlers import XTPacket
 from houdini.data.penguin import Penguin
 from houdini.handlers.games.ninja.card import get_threshold_for_rank, get_exp_difference_to_next_rank
+from houdini.handlers.games.ninja.fire import get_fire_rank_threshold
 
 # rank doesn't need to be known, but requiring it since it is always known and is simpler/faster to compute
 def get_percentage_to_next_belt(xp: int, rank: int) -> int:
     return int(((xp - get_threshold_for_rank(rank)) / get_exp_difference_to_next_rank(rank)) * 100)
+
+def get_percentage_to_next_fire_item(xp: int, rank: int) -> int:
+    if rank >= 4:
+        return 0
+    cur_threshold = get_fire_rank_threshold(rank)
+    return int((xp - cur_threshold) / (get_fire_rank_threshold(rank + 1) - cur_threshold) * 100)
 
 @handlers.handler(XTPacket('ni', 'gnr'))
 @handlers.cooldown(2)
@@ -22,7 +29,7 @@ async def handle_get_ninja_level(p):
 
 @handlers.handler(XTPacket('ni', 'gfl'))
 async def handle_get_fire_level(p):
-    await p.send_xt('gfl', p.fire_ninja_rank, p.fire_ninja_progress, 5)
+    await p.send_xt('gfl', p.fire_ninja_rank, get_percentage_to_next_fire_item(p.fire_ninja_progress, p.fire_ninja_rank), 5)
 
 
 @handlers.handler(XTPacket('ni', 'gwl'))


### PR DESCRIPTION
Similar to the Card-Jitsu one, changed how the percentages progress. I have a in-detail document for fire as well [here](https://docs.google.com/document/d/1n5-oSv_Yy0sqMtLHo6724X5XPuBz2aV8eFBYk16wn2Y/edit?usp=sharing), but overall:

1. Once again, mats give the same amount of EXP as random matches
2. Progress is restructured into an EXP system
3. The EXP from a match is determined by the number of people and how well you did
4. Added the same retro compatibility as the card-jitsu change, so likewise this one also will work with older databases