### PR TITLE
Fix igloo owner rejoining its open igloo after disconnecting

### DIFF
--- a/houdini/handlers/play/navigation.py
+++ b/houdini/handlers/play/navigation.py
@@ -147,7 +147,7 @@ async def create_temporary_room(p, penguin_id):
     igloo = None
     if penguin_id in p.server.penguins_by_id:
         igloo_owner = p.server.penguins_by_id[penguin_id]
-        igloo = igloo_owner.igloo_rooms[igloo_owner.igloo]
+        igloo = p.server.igloos_by_penguin_id.get(igloo_owner.id, igloo_owner.igloo_rooms[igloo_owner.igloo])
         p.server.igloos_by_penguin_id[penguin_id] = igloo
     elif penguin_id not in p.server.igloos_by_penguin_id:
         igloo = await PenguinIglooRoom.load(parent=Penguin.on(Penguin.igloo == PenguinIglooRoom.id)) \


### PR DESCRIPTION
# Context

I've observed the following scenario when joining player's igloos:

- Player A goes to its igloo and makes it public;
- Player B joins Player A's igloo;
- Player A disconnects from the game;
- Player A reconnects and goes to its own igloo again;

Both players should now be on Player A's igloo, but they will not see each other. Additionally, whoever leaves the igloo last will have its game crash (i.e., will be stuck on a loading screen indefinitely), raising the following exception:

```
Traceback (most recent call last):
  File "/usr/src/houdini/houdini/spheniscidae.py", line 174, in run
    await self.__data_received(data)
  File "/usr/src/houdini/houdini/spheniscidae.py", line 161, in __data_received
    await self.__handle_xt_data(data)
  File "/usr/src/houdini/houdini/spheniscidae.py", line 105, in __handle_xt_data
    await listener(self, packet_data)
  File "/usr/src/houdini/houdini/handlers/__init__.py", line 91, in __call__
    await super().__call__(p, packet_data)
  File "/usr/src/houdini/houdini/converters.py", line 139, in __call__
    raise e
  File "/usr/src/houdini/houdini/converters.py", line 131, in __call__
    return await self.callback(*handler_call_arguments, **handler_call_keywords)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/houdini/houdini/handlers/play/navigation.py", line 136, in handle_join_room
    await p.join_room(room)
  File "/usr/src/houdini/houdini/penguin.py", line 88, in join_room
    await room.add_penguin(self)
  File "/usr/src/houdini/houdini/data/room.py", line 137, in add_penguin
    await RoomMixin.add_penguin(self, p)
  File "/usr/src/houdini/houdini/data/room.py", line 30, in add_penguin
    await p.room.remove_penguin(p)
  File "/usr/src/houdini/houdini/data/room.py", line 201, in remove_penguin
    del p.server.igloos_by_penguin_id[self.penguin_id]
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 103
```

# Solution

Check for already loaded player's igloo before pulling a new igloo_room instance from igloo's owner penguin instance.