### PR TITLE
Fix Rainbow Puffle Quest Coins Collected UI not working

### DIFF
--- a/houdini/handlers/play/rainbow.py
+++ b/houdini/handlers/play/rainbow.py
@@ -47,7 +47,7 @@ async def handle_rainbow_quest_cookie(p):
 
     current_datetime = datetime.now()
     task_completion = await p.server.redis.get(f'houdini.rainbow_completion.{p.id}')
-    coins_collected = await p.server.redis.smembers(f'houdini.rainbow_coins.{p.id}')
+    coins_collected = {c.decode() for c in await p.server.redis.smembers(f'houdini.rainbow_coins.{p.id}')}
 
     if task_completion:
         quest_wait = RainbowQuestWaitMember if p.is_member else RainbowQuestWait


### PR DESCRIPTION
This fixes the rainbow puffle quest UI not showing correctly if the coins were collected or not.

It was comparing stored Bytes in Redis with a task_id as Int, making it always returns False, and the UI offering the collect coins.
By first decoding the Redis result into int, and then comparing, it works properly again.