### PR TITLE
Fix RedemptionCode case insensitivity check

### DIFF
--- a/houdini/handlers/redemption/code.py
+++ b/houdini/handlers/redemption/code.py
@@ -144,7 +144,7 @@ async def handle_code_legacy(p, redemption_code: str):
     query = RedemptionCode.distinct(RedemptionCode.id)\
         .load(cards=RedemptionAwardCard.distinct(RedemptionAwardCard.card_id),
               items=RedemptionAwardItem.distinct(RedemptionAwardItem.item_id))\
-        .query.where(RedemptionCode.code.upper() == redemption_code.upper())
+        .query.where(db.func.upper(RedemptionCode.code) == redemption_code.upper())
     codes = await query.gino.all()
     if not codes:
         return await p.send_error(720)
@@ -200,7 +200,7 @@ async def handle_code_vanilla(p, redemption_code: str):
               locations=RedemptionAwardLocation.distinct(RedemptionAwardLocation.location_id),
               puffles=RedemptionAwardPuffle.distinct(RedemptionAwardPuffle.puffle_id),
               puffle_items=RedemptionAwardPuffleItem.distinct(RedemptionAwardPuffleItem.puffle_item_id))\
-        .query.where(RedemptionCode.code.upper() == redemption_code.upper())
+        .query.where(db.func.upper(RedemptionCode.code) == redemption_code.upper())
     codes = await query.gino.all()
     if not codes:
         return await p.send_error(720)


### PR DESCRIPTION
A bit over a week ago this commit got merged which broke code redemptions: [`2943024` (#107)](https://github.com/solero/houdini/pull/107/commits/2943024f8894b50de9d72335ca7ac9f25f3ae722)

It would throw this error:
```python
[ERROR]  <traceback object at 0x14ca6a5a1e40>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 747, in __getattr__
    return getattr(self.comparator, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Comparator' object has no attribute 'upper'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/houdini/houdini/spheniscidae.py", line 174, in run
    await self.__data_received(data)
  File "/usr/src/houdini/houdini/spheniscidae.py", line 161, in __data_received
    await self.__handle_xt_data(data)
  File "/usr/src/houdini/houdini/spheniscidae.py", line 105, in __handle_xt_data
    await listener(self, packet_data)
  File "/usr/src/houdini/houdini/handlers/__init__.py", line 91, in __call__
    await super().__call__(p, packet_data)
  File "/usr/src/houdini/houdini/converters.py", line 139, in __call__
    raise e
  File "/usr/src/houdini/houdini/converters.py", line 131, in __call__
    return await self.callback(*handler_call_arguments, **handler_call_keywords)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/houdini/houdini/handlers/redemption/code.py", line 147, in handle_code_legacy
    .query.where(RedemptionCode.code.upper() == redemption_code.upper())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 749, in __getattr__
    util.raise_(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
AttributeError: Neither 'Column' object nor 'Comparator' object has an attribute 'upper'
```